### PR TITLE
add users fetch

### DIFF
--- a/capstone-prep-client/src/App.jsx
+++ b/capstone-prep-client/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Routes, Route, Link } from "react-router-dom";
 import Login from "./components/Login.jsx";
 import Registration from "./components/Registration";
+import Home from "./components/Home";
 import store from "./app/store.js";
 import { Provider } from "react-redux";
 import Protected from "./components/Protected.jsx";

--- a/capstone-prep-client/src/app/api.js
+++ b/capstone-prep-client/src/app/api.js
@@ -4,7 +4,8 @@ import { createSlice } from "@reduxjs/toolkit";
 export const api = createApi({
   reducerPath: "api",
   baseQuery: fetchBaseQuery({
-    baseUrl: "http://capstone-prep-backend-vjwd.onrender.com/",
+    baseUrl: "https://capstone-prep-backend-vjwd.onrender.com/",
+
     prepareHeaders: (headers) => {
       const token = window.sessionStorage.getItem("Token");
       if (token) {
@@ -14,6 +15,10 @@ export const api = createApi({
     },
   }),
   tagTypes: ["User"],
+  endpoints: () => ({}),
+});
+
+const registrationApi = api.injectEndpoints({
   endpoints: (builder) => ({
     registration: builder.mutation({
       query: (credentials) => ({
@@ -23,6 +28,11 @@ export const api = createApi({
       }),
       invalidateTags: ["User"],
     }),
+  }),
+});
+
+const loginApi = api.injectEndpoints({
+  endpoints: (builder) => ({
     login: builder.mutation({
       query: (credentials) => ({
         url: "/api/user/login",
@@ -64,9 +74,32 @@ const loginSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addMatcher(api.endpoints.login.matchFulfilled, setToken);
+    builder.addMatcher(api.endpoints.login.matchFulfilled, setLoginToken);
   },
 });
+
+//******************************* */
+// From Classroom Manager Example for use in user update/display/delete
+export function providesList(tagType) {
+  return (resultsWithIds) => {
+    console.log(resultsWithIds);
+    resultsWithIds
+      ? [
+          { type: tagType, id: "LIST" },
+          ...resultsWithIds.map(({ id }) => ({ type: tagType, id })),
+        ]
+      : [{ type: tagType, id: "LIST" }];
+  };
+}
+
+export function providesId(tagType) {
+  return (result, error, id) => [{ type: tagType, id }];
+}
+
+export function invalidatesId(tagType) {
+  return (result, error, arg) => [{ type: tagType, id: arg.id }];
+}
+//******************************** */
 
 export const { useRegistrationMutation, useLoginMutation } = api;
 

--- a/capstone-prep-client/src/components/Home.jsx
+++ b/capstone-prep-client/src/components/Home.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import UserTable from "./userTable";
+
+export default function Home() {
+  return (
+    <div>
+      <div>Home</div>
+      <div>
+        <UserTable />
+      </div>
+    </div>
+  );
+}

--- a/capstone-prep-client/src/components/Login.jsx
+++ b/capstone-prep-client/src/components/Login.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useLoginMutation } from "./../app/api";
 import Foot from "./Foot";
 
-export default function Registration() {
+export default function Login() {
   const [form, setForm] = useState({});
   const [errM, setErrM] = useState(null);
   const navigate = useNavigate();

--- a/capstone-prep-client/src/components/Protected.jsx
+++ b/capstone-prep-client/src/components/Protected.jsx
@@ -2,10 +2,9 @@ import { Navigate, Outlet } from "react-router-dom";
 
 export default function Protected() {
   const sessionToken = window.sessionStorage.getItem("Token");
-  //   console.log("Protected", token);
 
   if (!sessionToken) {
-    return <Navigate to="/login" />;
+    return <Navigate to="/Login" />;
   }
 
   return <Outlet />;

--- a/capstone-prep-client/src/components/Registration.jsx
+++ b/capstone-prep-client/src/components/Registration.jsx
@@ -74,7 +74,7 @@ export default function Registration() {
                 type="text"
                 className="form-control"
                 placeholder="First Name"
-                name="firstName"
+                name="firstname"
                 onChange={updateForm}
               />
             </div>
@@ -85,7 +85,7 @@ export default function Registration() {
                 type="text"
                 className="form-control"
                 placeholder="Last Name"
-                name="lastName"
+                name="lastname"
                 onChange={updateForm}
               />
             </div>

--- a/capstone-prep-client/src/components/user.jsx
+++ b/capstone-prep-client/src/components/user.jsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useUpdateUserMutation, useDeleteUserMutation } from "./userSlice";
+
+/**
+ * Displays user information and allows users to either
+ * update or delete the user.
+ */
+function User({ user }) {
+  const [deleteUser] = useDeleteUserMutation();
+  const [updateUser] = useUpdateUserMutation();
+
+  const [editing, setEditing] = useState(false);
+  const [email, setEmail] = useState(user.email);
+  const [password, setPassword] = useState(user.password);
+  const [lastname, setLastname] = useState(user.lastname);
+  const [firstname, setFirstname] = useState(user.firstname);
+
+  function onEdit(event) {
+    event.preventDefault();
+    if (editing) {
+      updateUser({ id: user.id, email, password, lastname, firstname });
+    }
+    setEditing(!editing);
+  }
+
+  const editFields = (
+    <>
+      <td>
+        <input
+          type="text"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </td>
+      <td>
+        <input
+          type="text"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </td>
+      <td>
+        <input
+          type="text"
+          value={firstname}
+          onChange={(e) => setFirstname(e.target.value)}
+        />
+      </td>
+      <td>
+        <input
+          type="text"
+          value={lastname}
+          onChange={(e) => setLastname(e.target.value)}
+        />
+      </td>
+    </>
+  );
+
+  return (
+    <tr>
+      {editing ? (
+        editFields
+      ) : (
+        <>
+          <td>{email}</td>
+          <td>{password}</td>
+          <td>{lastname}</td>
+          <td>{firstname}</td>
+        </>
+      )}
+      <td>
+        <button onClick={onEdit}>{editing ? "Save" : "Edit"}</button>
+        <button onClick={() => deleteUser(user.id)}>Delete</button>
+      </td>
+    </tr>
+  );
+}
+
+export default User;

--- a/capstone-prep-client/src/components/userForm.jsx
+++ b/capstone-prep-client/src/components/userForm.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function userForm() {
+  return (
+    <div>userForm</div>
+  )
+}

--- a/capstone-prep-client/src/components/userSlice.js
+++ b/capstone-prep-client/src/components/userSlice.js
@@ -1,0 +1,43 @@
+import { api, invalidatesId, providesId, providesList } from "../app/api";
+
+/**
+ * API endpoints
+ */
+const usersApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    getUsers: builder.query({
+      query: () => "api/user/users",
+      // needs debugging --- >
+      //providesTags: providesList("User"),
+      tags: "User",
+    }),
+
+    getUser: builder.query({
+      query: (id) => `api/user/users/${id}`,
+      providesTags: providesId("User"),
+      tags: "User",
+    }),
+    updateUser: builder.mutation({
+      query: (user) => ({
+        url: `api/user/users/${user.id}`,
+        method: "PUT",
+        body: user,
+      }),
+      invalidatesTags: invalidatesId("User"),
+    }),
+    deleteUser: builder.mutation({
+      query: (id) => ({
+        url: `api/user/delete/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: invalidatesId("User"),
+    }),
+  }),
+});
+
+export const {
+  useGetUsersQuery,
+  useGetUserQuery,
+  useUpdateUserMutation,
+  useDeleteUserMutation,
+} = usersApi;

--- a/capstone-prep-client/src/components/userTable.css
+++ b/capstone-prep-client/src/components/userTable.css
@@ -1,0 +1,7 @@
+table td {
+    width: 10em;
+  }
+  
+  table td input {
+    width: 100%;
+  }

--- a/capstone-prep-client/src/components/userTable.jsx
+++ b/capstone-prep-client/src/components/userTable.jsx
@@ -1,0 +1,37 @@
+import User from "./user";
+import { useGetUsersQuery } from "./userSlice";
+import "./userTable.css";
+
+/**
+ * UserList displays a list of users
+ */
+function UserTable() {
+  const { data: users, error, isLoading } = useGetUsersQuery();
+  const usersArray = users && users["users"];
+  console.log(usersArray);
+
+  return (
+    <section>
+      <h2>Users</h2>
+      {isLoading && <p>Loading...</p>}
+      {error && <p>Something went wrong: {error.message}</p>}
+      <table>
+        <thead>
+          <tr>
+            <th>Email</th>
+            <th>Password</th>
+            <th>Lastname</th>
+            <th>Firstname</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users &&
+            usersArray.map((user) => <User key={user.id} user={user} />)}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+export default UserTable;


### PR DESCRIPTION
Added the user fetch which include some already set up editing and deleting capability.   Adjusted a bit the way we set up api.js for login and register to accommodate the way the users list is being handled.

Some things to note:
1) Login doesn't let you know when your login failed, it just re-displays the login form
2) The delete is working, but not refreshing on the screen (most likely to do with some debugging needed in
   userAPI.providesList("User") call when doing the fetch for all users. 
3) Editing a user updates the password (it hashes the hash) - perhaps we need to display a blank for password 
   so a user if forced to re-input?
